### PR TITLE
Documentation fix for random.gauss

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -326,7 +326,7 @@ be found in any statistics text.
 
 .. function:: gauss(mu, sigma)
 
-   Gaussian distribution.  *mu* is the mean, and *sigma* is the standard
+   Normal distribution.  *mu* is the mean, and *sigma* is the standard
    deviation.  This is slightly faster than the :func:`normalvariate` function
    defined below.
 


### PR DESCRIPTION
Keep the documentation of random.gauss and random.normalvariate in line, because they represent the same thing. The current state of calling the one "Gaussian distribution" and the other "Normal distribution" can cause confusion. They are both the same distribution.